### PR TITLE
Clean up of old plugins that aren't used

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -94,7 +94,6 @@ WORKDIR /octoprint
  RUN PYTHONUSERBASE=/octoprint/plugins/ pip install --no-cache-dir \
      "https://github.com/tg44/OctoPrint-Prometheus-Exporter/archive/refs/tags/0.1.7.zip" \
      "https://github.com/gdombiak/OctoPrint-OctoPod/archive/refs/tags/0.3.13.zip" \
-     "https://github.com/tideline3d/OctoPrint-PrintJobHistory-ExternalDatabase/archive/refs/tags/1.2.1.zip" \
      "https://github.com/markwal/OctoPrint-SnapStream/archive/refs/tags/0.3.zip" \
      "https://github.com/OctoPrint/OctoPrint-FirmwareUpdater/archive/refs/tags/1.13.2.zip" \
      "https://github.com/Birkbjo/OctoPrint-Themeify/archive/refs/tags/v1.2.2.zip" \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -88,27 +88,19 @@ ENV PATH "${PYTHONUSERBASE}/bin:${PATH}"
 # set WORKDIR 
 WORKDIR /octoprint
 
-#Install FilamentManager Dep
- RUN PYTHONUSERBASE=/octoprint/plugins/ pip install --no-cache-dir "psycopg2"
-
  RUN PYTHONUSERBASE=/octoprint/plugins/ pip install --no-cache-dir \
-     "https://github.com/tg44/OctoPrint-Prometheus-Exporter/archive/refs/tags/0.1.7.zip" \
      "https://github.com/gdombiak/OctoPrint-OctoPod/archive/refs/tags/0.3.13.zip" \
      "https://github.com/markwal/OctoPrint-SnapStream/archive/refs/tags/0.3.zip" \
      "https://github.com/OctoPrint/OctoPrint-FirmwareUpdater/archive/refs/tags/1.13.2.zip" \
      "https://github.com/Birkbjo/OctoPrint-Themeify/archive/refs/tags/v1.2.2.zip" \
      "https://github.com/eyal0/OctoPrint-PrintTimeGenius/archive/refs/tags/2.2.8.zip" \
-    # #"https://github.com/jneilliii/OctoPrint-TPLinkSmartplug/archive/refs/tags/1.0.1.zip" \
      "https://github.com/tideline3d/OctoPrint-GitFiles/archive/refs/heads/master.zip" \
      "https://github.com/jneilliii/OctoPrint-BedLevelVisualizer/archive/refs/tags/1.1.1.zip" \
-    # #"https://github.com/OllisGit/OctoPrint-FilamentManager/releases/download/1.8.1/master.zip" \
      "https://github.com/jneilliii/OctoPrint-CustomBackground/archive/refs/tags/1.0.0.zip" \
      "https://github.com/jneilliii/OctoPrint-PrusaSlicerThumbnails/archive/refs/tags/1.0.0.zip"\
      "https://github.com/paukstelis/Octoprint-Cancelobject/archive/refs/tags/0.4.6.tar.gz" \
-    # #"https://github.com/2blane/OctoPrint-Webhooks/archive/refs/tags/3.0.3.zip" 
-    #"https://github.com/QuinnDamerell/OctoPrint-OctoEverywhere/archive/refs/tags/1.6.6.zip" \
-     https://github.com/cmroche/OctoPrint-HomeAssistant/archive/refs/tags/3.6.1.zip \
-     https://github.com/OctoPrint/OctoPrint-MQTT/archive/refs/tags/0.8.12.zip 
+     "https://github.com/cmroche/OctoPrint-HomeAssistant/archive/refs/tags/3.6.1.zip" \
+     "https://github.com/OctoPrint/OctoPrint-MQTT/archive/refs/tags/0.8.12.zip" 
 
 # port to access haproxy frontend
 EXPOSE 80

--- a/root/octoprint/octoprint/config.yaml.template
+++ b/root/octoprint/octoprint/config.yaml.template
@@ -21,20 +21,6 @@ plugins:
       command: "G80\t\t\t; run mesh bed leveling routine.\n@BEDLEVELVISUALIZER\t\
           ; instruct plugin to start recording responses from printer.\nG81\t\t\t\
           ; report mesh bed leveling status."
-  PrintJobHistory:
-    selectedFilamentTrackerPlugin: no plugin installed/enabled
-    capturePrintJobHistoryMode: always
-    externalDatabase:
-      database_name: postgres #make this a variable soon
-      enabled: $PRINT_JOB_HISTORY_EXTERNAL_DB
-      host: $POSTGRES_HOST #make this a variable soon
-      password: $POSTGRES_PASSWORD #make this a variable soon
-      port: '5432'
-      username: $POSTGRES_USERNAME #make this a variable soon
-    pluginCheckActivated: false
-    showPrintJobDialogAfterPrint: false
-    takePluginThumbnailAfterPrint: false
-    sqlLoggingEnabled: true
   snapstream:
     fallbackonly: false
     url: http://$OCTOPRINT_HOSTNAME.local:8080/images/live.jpg


### PR DESCRIPTION
Removing PrintJob History as it causes startup slowness as the database grows.   We'll use MQTT > Influx for this in the future. 

Dropping Prometheus as MQTT  > Influx will give us this data too.  

Cleaned out old commented ones that didnt need to linger. 