### PR TITLE
Remove balena_  prefix from hostname on Octoprint instance

### DIFF
--- a/root/etc/cont-init.d/03-set-hostname
+++ b/root/etc/cont-init.d/03-set-hostname
@@ -1,6 +1,6 @@
 #!/usr/bin/with-contenv bash
 
 curl -X PATCH --header "Content-Type:application/json" \
-    --data "{\"network\": {\"hostname\": \"balena_$OCTOPRINT_HOSTNAME\"}}" \
+    --data "{\"network\": {\"hostname\": \"$OCTOPRINT_HOSTNAME\"}}" \
     "$BALENA_SUPERVISOR_ADDRESS/v1/device/host-config?apikey=$BALENA_SUPERVISOR_API_KEY"
 


### PR DESCRIPTION
We want it hitting our mDNS container's entry, not the hostOS